### PR TITLE
Move to rich for logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ colorama = "^0.4.4"
 rsa = "^4.8"
 rich = "^12.4.4"
 toml = "^0.10.2"
-coloredlogs = {version = "^15.0.1", optional = true}
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"

--- a/zerocom/utils/log.py
+++ b/zerocom/utils/log.py
@@ -17,14 +17,11 @@ LOG_FORMAT = "%(asctime)s | %(name)s | %(levelname)7s | %(message)s"
 def setup_logging() -> None:
     """Sets up logging library to use our log format and defines log levels."""
     root_log = logging.getLogger()
-    log_formatter = logging.Formatter(LOG_FORMAT)
+    log_formatter = logging.Formatter(LOG_FORMAT, datefmt="%Y-%m-%d %H:%M:%S")
 
-    logging.basicConfig(
-        level=LOG_LEVEL,
-        format=LOG_FORMAT,
-        handlers=[RichHandler(show_time=False)],
-        datefmt="%Y-%m-%d %H:%M:%S",  # TODO: Add millisecond precision
-    )
+    rich_handler = RichHandler(show_time=False)
+    rich_handler.setFormatter(log_formatter)
+    root_log.addHandler(rich_handler)
 
     if LOG_FILE is not None:
         file_handler = logging.handlers.RotatingFileHandler(Path(LOG_FILE), maxBytes=LOG_FILE_MAX_SIZE)

--- a/zerocom/utils/log.py
+++ b/zerocom/utils/log.py
@@ -2,17 +2,11 @@ from __future__ import annotations
 
 import logging
 import logging.handlers
-import os
-import sys
 from pathlib import Path
 
+from rich.logging import RichHandler
+
 import zerocom.config
-
-try:
-    import coloredlogs  # type: ignore # pyright complains if this isn't installed
-except ImportError:
-    coloredlogs = None
-
 
 LOG_LEVEL = logging.DEBUG if zerocom.config.DEBUG else logging.INFO
 LOG_FILE = zerocom.config.LOG_FILE
@@ -25,21 +19,12 @@ def setup_logging() -> None:
     root_log = logging.getLogger()
     log_formatter = logging.Formatter(LOG_FORMAT)
 
-    if coloredlogs is not None:
-        if "COLOREDLOGS_LOG_FORMAT" not in os.environ:
-            coloredlogs.DEFAULT_LOG_FORMAT = LOG_FORMAT
-
-        if "COLOREDLOGS_LEVEL_STYLES" not in os.environ:
-            coloredlogs.DEFAULT_LEVEL_STYLES = {
-                **coloredlogs.DEFAULT_LEVEL_STYLES,
-                "critical": {"background": "red"},
-            }
-
-        coloredlogs.install(level=logging.DEBUG, logger=root_log, stream=sys.stdout)
-    else:
-        stdout_handler = logging.StreamHandler(stream=sys.stdout)
-        stdout_handler.setFormatter(log_formatter)
-        root_log.addHandler(stdout_handler)
+    logging.basicConfig(
+        level=LOG_LEVEL,
+        format=LOG_FORMAT,
+        handlers=[RichHandler(show_time=False)],
+        datefmt="%Y-%m-%d %H:%M:%S",  # TODO: Add millisecond precision
+    )
 
     if LOG_FILE is not None:
         file_handler = logging.handlers.RotatingFileHandler(Path(LOG_FILE), maxBytes=LOG_FILE_MAX_SIZE)


### PR DESCRIPTION
Move to the `RichHandler` available for the `logging` module in Python instead of using the `coloredlogs` dependency (optional).