### PR TITLE
Coverage ignore patterns

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,8 @@ exclude_lines =
     pragma: no cover
     if TYPE_CHECKING:
     @(abc\.)?abstractmethod
+    @(typing\.)?overload
+    def __repr__
+    class .*\bProtocol\):
+    raise NotImplementedError
+    ^\s\.\.\.\s$

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [report]
 exclude_lines =
-    pragma: nocover
+    pragma: no cover
     if TYPE_CHECKING:
     @abstractmethod

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,4 @@
 exclude_lines =
     pragma: no cover
     if TYPE_CHECKING:
-    @abstractmethod
+    @(abc\.)?abstractmethod


### PR DESCRIPTION
This adds several new patterns for which coverage shouldn't be measured, and adjusts some already present ones.

Specifying these allows for our coverage reports to skip measuring coverage on things that will never actually run anyway, such as overload implementations, content of typing protocol classes, bodies of abstractmethods, and several other things.